### PR TITLE
fix: TestRefreshHandlerRS256 fails in CI due to incorrect assertion

### DIFF
--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -499,7 +499,17 @@ func TestRefreshHandlerRS256(t *testing.T) {
 	resp := w.Result()
 	assert.DeepEqual(t, "refresh successfully", gjson.Get(string(resp.BodyBytes()), "message").String())
 	assert.DeepEqual(t, http.StatusOK, w.Code)
-	assert.DeepEqual(t, makeTokenString("RS256", "admin"), gjson.Get(string(resp.BodyBytes()), "cookie").String())
+
+	// Verify that a new token is returned and can be parsed
+	refreshedTokenString := gjson.Get(string(resp.BodyBytes()), "cookie").String()
+	assert.True(t, len(refreshedTokenString) > 0)
+
+	// Verify the refreshed token can be parsed
+	refreshedToken, err := authMiddleware.ParseTokenString(refreshedTokenString)
+	assert.Nil(t, err)
+	refreshedClaims := ExtractClaimsFromToken(refreshedToken)
+	assert.True(t, len(refreshedClaims) > 0)
+	assert.NotNil(t, refreshedClaims["identity"])
 }
 
 func TestRefreshHandler(t *testing.T) {

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -493,9 +493,10 @@ func TestRefreshHandlerRS256(t *testing.T) {
 	w = ut.PerformRequest(handler, http.MethodGet, "/auth/refresh_token", nil, ut.Header{Key: "Authorization", Value: "Test 1234"})
 	assert.DeepEqual(t, http.StatusUnauthorized, w.Code)
 
+	token := makeTokenString("RS256", "admin")
 	w = ut.PerformRequest(handler, http.MethodGet, "/auth/refresh_token", nil,
-		ut.Header{Key: "Authorization", Value: "Bearer " + makeTokenString("RS256", "admin")},
-		ut.Header{Key: "Cookie", Value: "jwt=" + makeTokenString("RS256", "admin")})
+		ut.Header{Key: "Authorization", Value: "Bearer " + token},
+		ut.Header{Key: "Cookie", Value: "jwt=" + token})
 	resp := w.Result()
 	assert.DeepEqual(t, "refresh successfully", gjson.Get(string(resp.BodyBytes()), "message").String())
 	assert.DeepEqual(t, http.StatusOK, w.Code)


### PR DESCRIPTION
## 修复 TestRefreshHandlerRS256 测试用例中的错误断言

### 问题描述

在修复 issue #26（orig_iat 重置问题）后，`TestRefreshHandlerRS256` 测试用例在 CI 环境中失败，但在本地环境中通过。

### CI 失败日志

[CI 失败日志](https://github.com/hertz-contrib/jwt/actions/runs/20218317752/job/58035178690)

### 原因分析

测试用例第502行有一个错误的断言：

assert.DeepEqual(t, makeTokenString("RS256", "admin"), gjson.Get(string(resp.BodyBytes()), "cookie").String())这个断言期望刷新后的 token 和重新生成的 token 相同，但这是不正确的，因为：

1. **刷新后的 token 会保留原始的 `orig_iat`**（修复 issue #26 后的正确行为）
2. **重新调用 `makeTokenString` 会生成新的 `orig_iat`**（当前时间）
3. 即使在同一秒内，由于 `exp` 时间可能不同，token 字符串也会不同

### 为什么本地测试通过而 CI 失败？

在本地环境中，如果所有操作都在同一秒内完成，`time.Now().Unix()` 可能返回相同的值，导致：

- 原始 token 的 `orig_iat = T1`
- 刷新后的 token 的 `orig_iat = T1`（保留，正确行为）
- 重新生成的 token 的 `orig_iat = T1`（巧合，因为时间戳相同）

如果 `exp` 也相同，token 字符串可能相同，测试"巧合"通过。

在 CI 环境中，由于执行时间不同，这些时间戳不同，测试失败。

### 修复内容

- ✅ 移除错误的 token 字符串比较断言
- ✅ 添加合理的验证：
  - 验证刷新后的 token 不为空
  - 验证刷新后的 token 可以成功解析
  - 验证刷新后的 token 包含必要的 claims（identity）
- ✅ 保持测试用例的单一职责：`orig_iat` 的验证由 `TestOrigIatPreservedOnRefresh` 负责

### 测试验证

- ✅ `TestRefreshHandlerRS256` 通过
- ✅ `TestOrigIatPreservedOnRefresh` 通过
- ✅ 所有现有测试继续通过

### 相关链接

- Fixes #28 
- Related to #26 (已修复的 orig_iat 问题)
- Related to #27 (修复 orig_iat 的 PR)