### PR TITLE
fix: normalize expired token error in GetClaimsFromJWT to ErrExpiredToken

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -514,6 +514,15 @@ func (mw *HertzJWTMiddleware) middlewareImpl(ctx context.Context, c *app.Request
 func (mw *HertzJWTMiddleware) GetClaimsFromJWT(ctx context.Context, c *app.RequestContext) (MapClaims, error) {
 	token, err := mw.ParseToken(ctx, c)
 	if err != nil {
+		// Normalize expired token errors to the sentinel ErrExpiredToken,
+		// consistent with CheckIfTokenExpire behavior.
+		// Without this, *jwt.ValidationError is returned as-is,
+		// making it impossible to match with == ErrExpiredToken downstream.
+		validationErr, ok := err.(*jwt.ValidationError)
+		if ok && validationErr.Errors == jwt.ValidationErrorExpired {
+			return nil, ErrExpiredToken
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
## Problem

`GetClaimsFromJWT` returns the raw `*jwt.ValidationError` from `ParseToken` when a token is expired. This makes it impossible for downstream `HTTPStatusMessageFunc` to identify expired tokens via `== ErrExpiredToken`, since `*jwt.ValidationError` and the sentinel `ErrExpiredToken` are different types.

### Root Cause

`CheckIfTokenExpire` (used in the refresh flow) already handles this correctly:

```go
func (mw *HertzJWTMiddleware) CheckIfTokenExpire(...) (jwt.MapClaims, error) {
    token, err := mw.ParseToken(ctx, c)
    if err != nil {
        validationErr, ok := err.(*jwt.ValidationError)
        if !ok || validationErr.Errors != jwt.ValidationErrorExpired {
            return nil, err  // only propagate non-expiry errors
        }
    }
    // continues to check MaxRefresh window...
}
```

However, `GetClaimsFromJWT` (used in the auth flow via `middlewareImpl`) lacks the same normalization:

```go
func (mw *HertzJWTMiddleware) GetClaimsFromJWT(...) (MapClaims, error) {
    token, err := mw.ParseToken(ctx, c)
    if err != nil {
        return nil, err  // returns raw *jwt.ValidationError as-is
    }
    // ...
}
```

### Impact

1. **Inconsistent error types**: `middlewareImpl` receives `*jwt.ValidationError` for expired tokens, while `ErrExpiredToken` is the documented sentinel error. Custom `HTTPStatusMessageFunc` implementations that check `err == ErrExpiredToken` will never match.

2. **Dead code in `middlewareImpl`**: The manual `exp` check (lines 475-496) is unreachable for expired tokens because `GetClaimsFromJWT` already returns an error before claims are available:

```go
claims, err := mw.GetClaimsFromJWT(ctx, c)
if err != nil {
    mw.unauthorized(...)  // *jwt.ValidationError is passed here
    return                // exits before reaching the exp check below
}

// This code is never reached for expired tokens:
switch v := claims["exp"].(type) {
case float64:
    if int64(v) < mw.TimeFunc().Unix() {
        mw.unauthorized(ctx, c, http.StatusUnauthorized, mw.HTTPStatusMessageFunc(ErrExpiredToken, ctx, c))
```

## Fix

Normalize `*jwt.ValidationError` with only `ValidationErrorExpired` to the sentinel `ErrExpiredToken` in `GetClaimsFromJWT`, consistent with `CheckIfTokenExpire` behavior.

## Testing

All existing tests pass. The fix is backward-compatible — only the error type changes from `*jwt.ValidationError` to `ErrExpiredToken` for the specific case of expired tokens. Both error types have the same semantic meaning ("token is expired"), but `ErrExpiredToken` is the expected sentinel value that users compare against.